### PR TITLE
[eye.hpp] restore eye display function

### DIFF
--- a/include/eye.hpp
+++ b/include/eye.hpp
@@ -272,4 +272,9 @@ public:
 
     sprite_eye.pushRotateZoom(&lcd, lcd.width() >> 1, lcd.height() >> 1, 0, zoom_ratio, zoom_ratio, TFT_WHITE);
   }
+
+  void draw_updated_image()
+  {
+    sprite_eye.pushRotateZoom(&lcd, lcd.width() >> 1, lcd.height() >> 1, 0, zoom_ratio, zoom_ratio, TFT_WHITE);
+  }
 };


### PR DESCRIPTION
@sawada10 @heissereal 
I restored the removed function to show eye to LCD. 
I conifrmed `simple_version` is working well. 
Please review this PR.